### PR TITLE
refactor: improve Helm module management and fix output extraction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build \
 RUN mkdir -p /internal-data && \
     chown -R 65532:65532 /internal-data
 
-FROM alpine:latest
+FROM alpine:3.22.2
 
 RUN apk add --no-cache git && \
     addgroup -g 65532 nonroot && \

--- a/api/v1/module_types.go
+++ b/api/v1/module_types.go
@@ -237,7 +237,6 @@ type ModuleStatus struct {
 
 	Phase ModulePhaseType `json:"phase"`
 
-	// Source indicates how this module is managed (e.g., "Adopted/Helm", "Managed/Git")
 	// +optional
 	Source string `json:"source,omitempty"`
 

--- a/config/crd/bases/batch.forkspacer.com_modules.yaml
+++ b/config/crd/bases/batch.forkspacer.com_modules.yaml
@@ -339,8 +339,6 @@ spec:
                 - failed
                 type: string
               source:
-                description: Source indicates how this module is managed (e.g., "Adopted/Helm",
-                  "Managed/Git")
                 type: string
             required:
             - phase

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -347,8 +347,6 @@ spec:
                 - failed
                 type: string
               source:
-                description: Source indicates how this module is managed (e.g., "Adopted/Helm",
-                  "Managed/Git")
                 type: string
             required:
             - phase

--- a/examples/module_helm.yaml
+++ b/examples/module_helm.yaml
@@ -5,94 +5,6 @@ metadata:
   namespace: default
 spec:
   source:
-    # raw:
-    #   kind: Helm
-    #   metadata:
-    #     name: redis
-    #     supportedOperatorVersion: ">= 0.0.0, < 1.0.0"
-
-    #   config:
-    #     - type: option
-    #       name: "Redis Version"
-    #       alias: "version"
-    #       spec:
-    #         editable: true
-    #         required: false
-    #         default: "21.2.9"
-    #         values:
-    #           - "21.2.9"
-    #           - "21.2.7"
-    #           - "21.2.6"
-
-    #     - type: integer
-    #       name: "Replica Count"
-    #       alias: "replicaCount"
-    #       spec:
-    #         editable: true
-    #         required: false
-    #         default: 1
-    #         min: 0
-    #         max: 5
-
-    #   spec:
-    #     namespace: alma
-    #     chart:
-    #       # repo:
-    #       #   url: https://charts.bitnami.com/bitnami
-    #       #   chartName: redis
-    #       #   version: "{{.config.version}}"
-    #       # configMap:
-    #       #   name: chart
-    #       # git:
-    #       #   repo: https://github.com/aykhans/test-chart
-    #       #   path: "/"
-    #       #   revision: main
-    #       #   auth:
-    #       #     httpsSecretRef:
-    #       #       name: git
-
-    #     values:
-    #       - file: https://ftp.aykhans.me/web/client/pubshares/hB6VSdCnBCr8gFPeiMuCji/browse?path=/values.yaml
-    #       - raw:
-    #           replica:
-    #             replicaCount: 0
-    #           image:
-    #             repository: bitnamilegacy/redis
-    #           global:
-    #             security:
-    #               allowInsecureImages: true
-
-    #     # outputs:
-    #     #   - name: "Redis Hostname"
-    #     #     value: "redis-master.default"
-    #     #   - name: "Redis Username"
-    #     #     value: "default"
-    #     #   - name: "Redis Password"
-    #     #     valueFrom:
-    #     #       secret:
-    #     #         name: "{{.releaseName}}"
-    #     #         key: redis-password
-    #     #         namespace: default
-    #     #   - name: "Redis Port"
-    #     #     value: 6379
-
-    #     cleanup:
-    #       removeNamespace: true
-    #       removePVCs: true
-
-    #     migration:
-    #       pvc:
-    #         enabled: true
-    #         names:
-    #           - "redis-data-{{.releaseName}}-master-0"
-    #       configMap:
-    #         enabled: false
-    #         names:
-    #           - ""
-    #       secret:
-    #         enabled: false
-    #         names:
-    #           - "{{.releaseName}}"
     existingHelmRelease:
       name: redis
       chartSource:
@@ -100,23 +12,7 @@ spec:
           url: https://charts.bitnami.com/bitnami
           chart: redis
           version: "21.2.9"
-      # Optional: Override specific values from the existing release
-      # These values will be merged with the existing release's values
-      # values:
-      #   replica:
-      #     replicaCount: 2
-      #   auth:
-      #     enabled: false
 
   workspace:
     name: default
     # namespace: default
-
-  # Automatically create the target namespace if it doesn't exist
-  # Useful for workspace forking to avoid resource conflicts
-  # +optional
-  # createNamespace: true
-
-  config:
-    version: 21.2.7
-    replicaCount: 0

--- a/internal/controller/module_controller.go
+++ b/internal/controller/module_controller.go
@@ -299,7 +299,7 @@ func (r *ModuleReconciler) newManager(
 				metaData[managerCons.HelmMetaDataKeys.ReleaseName] = releaseName
 			}
 
-			err := helmModule.RenderSpec(helmModule.NewRenderData(configMap, releaseName))
+			err := helmModule.RenderSpec(helmModule.NewRenderData(configMap, releaseName, helmModule.Spec.Namespace))
 			if err != nil {
 				return fmt.Errorf("failed to render Helm module spec: %v", err)
 			}

--- a/pkg/manager/helm.go
+++ b/pkg/manager/helm.go
@@ -293,7 +293,7 @@ func (m ModuleHelmManager) extractOutputs(ctx context.Context) *orderedmap.Order
 		} else if output.ValueFrom != nil {
 			if output.ValueFrom.Secret != nil && output.ValueFrom.Secret.Name != "" && output.ValueFrom.Secret.Key != "" {
 				namespace := output.ValueFrom.Secret.Namespace
-				if namespace != "" {
+				if namespace == "" {
 					namespace = kubernetesCons.Helm.DefaultNamespace
 				}
 
@@ -303,7 +303,12 @@ func (m ModuleHelmManager) extractOutputs(ctx context.Context) *orderedmap.Order
 					output.ValueFrom.Secret.Key,
 				)
 				if err != nil {
-					m.log.Error(err, "")
+					m.log.Error(err, "Failed to get secret value for output",
+						"outputName", output.Name,
+						"secretNamespace", namespace,
+						"secretName", output.ValueFrom.Secret.Name,
+						"secretKey", output.ValueFrom.Secret.Key,
+					)
 					continue
 				}
 

--- a/pkg/resources/helm.go
+++ b/pkg/resources/helm.go
@@ -244,9 +244,10 @@ func (module *HelmModule) RenderSpec(data any) error {
 	return nil
 }
 
-func (module *HelmModule) NewRenderData(config map[string]any, releaseName string) map[string]any {
+func (module *HelmModule) NewRenderData(config map[string]any, releaseName, namespace string) map[string]any {
 	return map[string]any{
 		"config":      config,
 		"releaseName": releaseName,
+		"namespace":   namespace,
 	}
 }


### PR DESCRIPTION
  - Pin Alpine base image to version 3.22.2 for reproducible builds
  - Refactor module source type detection logic to use "Source/Type" format (e.g., "Helm/Adopted", "Helm/Repo", "Helm/Git", "Custom")
  - Remove deprecated "forkspacer.com/adopted-release" annotations in favor of checking ExistingHelmRelease field directly
  - Fix secret output extraction bug: corrected namespace default condition from "!=" to "==" in helm.go:296